### PR TITLE
Split up Wireguard and conf URL DNS records

### DIFF
--- a/assets/caddy.tpl
+++ b/assets/caddy.tpl
@@ -18,7 +18,7 @@ metadata:
   namespace: ${app_name}
 data:
   Caddyfile: |
-    ${fqdn} {
+    ${conf_fqdn} {
       handle_path /* {
         basicauth {
           wg ${http_password}

--- a/assets/wireguard.tpl
+++ b/assets/wireguard.tpl
@@ -25,7 +25,7 @@ data:
   PUID: "1000"
   PGID: "1000"
   TZ: "America/Los_Angeles"
-  SERVERURL: ${fqdn}
+  SERVERURL: ${wg_fqdn}
   SERVERPORT: "51820"
   PEERS: "1"
   PEERDNS: "auto"

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,12 +2,16 @@ output "public_ip" {
   value = module.infrastructure.ipv4_address
 }
 
+output wg_server {
+  value = "${local.wg_fqdn}:51820"
+}
+
 output wg_qrcode_url {
-  value = "https://${local.fqdn}/peer1.png"
+  value = "https://${local.conf_fqdn}/peer1.png"
 }
 
 output wg_config_url {
-  value = "https://${local.fqdn}/peer1.conf"
+  value = "https://${local.conf_fqdn}/peer1.conf"
 }
 
 output http_username {

--- a/variables.tf
+++ b/variables.tf
@@ -1,18 +1,55 @@
 variable "hcloud_token" {
-  sensitive = true
+  description = "Hetzner Cloud API token."
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_https" {
+  description = "Enable automatic DNS updates through Cloudflare; domain must already exist."
+  type        = bool
+  default     = false
 }
 
 variable "cloudflare_token" {
-  sensitive = true
+  description = "Cloudflare API token."
+  type        = string
+  sensitive   = true
 }
 
-variable "app_name" { default = "wireguard" }
-variable "hostname" { default = "wg" }
-variable "http_username" { default = "wg" }
-variable "wg_subnet_cidr" { default = "192.168.10.0/24" }
+variable "domain_name" {
+  description = "Domain name used for Wireguard and Cloudflare if enabled."
+  type        = string
+}
+
+variable "app_name" {
+  type    = string
+  default = "wireguard"
+}
+
+variable "wireguard_hostname" {
+  description = "Hostname of Wireguard server."
+  type        = string
+  default     = "wg"
+}
+
+variable "conf_hostname" {
+  description = "Hostname of URL where to retrieve Wireguard client config and QR code."
+  type        = string
+  default     = "config"
+}
+
+variable "http_username" {
+  type    = string
+  default = "wg"
+}
+
+variable "wireguard_subnet_cidr" {
+  description = "Internal Wireguard subnet CIDR."
+  type        = string
+  default     = "192.168.10.0/24"
+}
 
 variable "datacenter" {}
-variable "domain_name" {}
 variable "image" {}
 variable "secrets_path" {}
 variable "server_name" {}


### PR DESCRIPTION
Split up Wireguard and conf URL DNS records to allow Cloudflare proxied records and better flexibility.